### PR TITLE
Fix: added default values

### DIFF
--- a/module.xml
+++ b/module.xml
@@ -98,9 +98,9 @@
 			<field name="module_name" type="string" length="80" default=""/>
 			<field name="event_name" type="string" length="80" default=""/>
 			<field name="event_status" type="string" length="10" default="Processing"/>
-			<field name="failure_reason" type="blob"/>
-			<field name="process_start_time" type="integer"/>
-			<field name="process_end_time" type="integer"/>
+			<field name="failure_reason" type="blob" default=""/>
+			<field name="process_start_time" type="integer" notnull="false"/>
+			<field name="process_end_time" type="integer" notnull="false"/>
 		</table>
 	</database>
 	<supported>


### PR DESCRIPTION
Added default values for:
- process_end_time
- process_start_time
- failure_reason
In api_asynchronous_transaction_history table